### PR TITLE
Allow binding to imposter engine cli rather than imposter-cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,22 +10,11 @@ jobs:
         with:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Install core module dependencies
         run: npm install
       - name: Test core module
         run: npm test
-      - name: Build core module
-        run: npm run build
-
-      - name: Install sample project dependencies
-        run: |
-          npm run prep-sample
-          npm install
-        working-directory: sample
-      - name: Test sample project
-        run: npm test
-        working-directory: sample
   build:
     needs: build-container
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,33 @@
 name: CI
 on: [push]
 jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    container: outofcoffee/imposter
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Install core module dependencies
+        run: npm install
+      - name: Test core module
+        run: npm test
+      - name: Build core module
+        run: npm run build
+
+      - name: Install sample project dependencies
+        run: |
+          npm run prep-sample
+          npm install
+        working-directory: sample
+      - name: Test sample project
+        run: npm test
+        working-directory: sample
   build:
+    needs: build-container
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/__tests__/version.test.js
+++ b/src/__tests__/version.test.js
@@ -9,7 +9,7 @@ describe('version reader', () => {
     it('can determine the CLI version', () => {
         const version = versionReader.determineCliVersion();
         console.debug(`CLI version: ${JSON.stringify(version)}`);
-        expect(version.major).toEqual(0);
+        expect(version.major).not.toBeNull();
     });
 
     it('runs version specific logic', () => {

--- a/src/configured-mock.js
+++ b/src/configured-mock.js
@@ -67,11 +67,26 @@ export class ConfiguredMock {
 
         this.proc = await new Promise(async (resolve, reject) => {
             try {
-                const args = [
-                    'up', this.configDir,
-                    `--port=${this.port}`,
-                    '--auto-restart=false',
-                ];
+                var args;
+
+                switch (this.utils.getCli()) {
+                    case 'imposter-cli':
+                        args = [
+                            'up', this.configDir,
+                            `--port=${this.port}`,
+                            '--auto-restart=false',
+                        ];
+                        break;
+                    case 'imposter':
+                        args = [
+                            `--configDir=${this.configDir}`,
+                            `--listenPort=${this.port}`,
+                        ];
+                        break;
+                    default:
+                        throw new Error('Failed to find an appropriate imposter cli to run');
+                }
+
                 if (localConfigFile) {
                     if (this.logVerbose) {
                         nodeConsole.debug(`Using project configuration: ${localConfigFile}`);
@@ -178,6 +193,10 @@ export class ConfiguredMock {
 }
 
 export class Utils {
+    getCli = () => {
+        return versionReader.determineCliVersion().cli;
+    }
+
     buildDebugAdvice = (logToFile, logVerbose, logFilePath) => {
         let advice = '';
         if (logToFile) {

--- a/src/version.js
+++ b/src/version.js
@@ -61,7 +61,7 @@ class VersionReader {
      * Determines the version of the CLI subcomponent.
      *
      * @param componentName {RegExp}
-     * @returns {{major: number, minor: number, revision: number}}
+     * @returns {{major: number, minor: number, revision: number, cli: string}}
      */
     determineVersion = (componentName) => {
         if (!this._initialised) {
@@ -85,6 +85,7 @@ class VersionReader {
                 major: Number(version[0]),
                 minor: Number(version[1]),
                 revision: Number(version[2]),
+                cli: 'imposter-cli',
             };
 
         } catch (e) {
@@ -95,11 +96,25 @@ class VersionReader {
     /**
      * Determine the version of the CLI.
      *
-     * @returns {{major: number, minor: number, revision: number}}
+     * @returns {{major: number, minor: number, revision: number, cli: string}}
      */
     determineCliVersion = () => {
         if (!this._cliVersion) {
-            this._cliVersion = this.determineVersion(/imposter-cli/);
+            try {
+                this._cliVersion = this.determineVersion(/imposter-cli/);
+            } catch(e) {
+                if (e.message.contains('Error parsing version') && this._versionOutput.startsWith('Version: ')) {
+                    const version = this._versionOutput.split('Version: ')[0];
+                    this._cliVersion = {
+                        major: Number(version[0]),
+                        minor: Number(version[1]),
+                        revision: Number(version[2]),
+                        cli: 'imposter',
+                    }
+                } else {
+                    throw e;
+                }
+            }
         }
         return this._cliVersion;
     }

--- a/src/version.js
+++ b/src/version.js
@@ -112,7 +112,7 @@ class VersionReader {
                 this._cliVersion = this.determineVersion(/imposter-cli/);
             } catch(e) {
                 if (e.message.startsWith('Error parsing version') && this._versionOutput.startsWith('Version: ')) {
-                    const version = this._versionOutput.split('Version: ')[0];
+                    const version = this._versionOutput.split('Version: ')[1].trim().split('.');
                     this._cliVersion = {
                         major: Number(version[0]),
                         minor: Number(version[1]),


### PR DESCRIPTION
Allows the running of unit tests or otherwise using the container hosted at: https://hub.docker.com/r/outofcoffee/imposter, without needing additional installs of the CLI, only npm.